### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/refresh/refresh.py
+++ b/refresh/refresh.py
@@ -50,7 +50,8 @@ class Refresh:
         _table_exists_action = f'table_exists_action={table_exists_action}'
 
         cmd = f'impdp "{_destination_db}" {_directory} {_network_link} {_tables} {_remap} {_table_exists_action}'
-        logger.info(cmd)
+        sanitized_cmd = cmd.replace(to_db_password, "****")
+        logger.info(sanitized_cmd)
         c = Cmd()
         c.run_cmd(cmd)
 
@@ -78,7 +79,8 @@ class Refresh:
         _table_exists_action = f'table_exists_action={table_exists_action}'
 
         cmd = f'impdp "{_destination_db}" {_directory} {_network_link} {_schemas} {_remap} {_table_exists_action}'
-        logger.info(cmd)
+        sanitized_cmd = cmd.replace(to_db_password, "****")
+        logger.info(sanitized_cmd)
         c = Cmd()
         c.run_cmd(cmd)
 


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/sdpr-cdw-data-pipelines/security/code-scanning/3](https://github.com/bcgov/sdpr-cdw-data-pipelines/security/code-scanning/3)

To fix the problem, we need to ensure that sensitive information such as passwords is not logged. Instead of logging the entire command, we can log a sanitized version of the command that omits the sensitive parts. This way, we maintain the ability to debug and monitor the application without exposing sensitive data.

We will modify the logging statement on line 53 to log a sanitized version of the `cmd` variable. Specifically, we will replace the password with a placeholder.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
